### PR TITLE
add ember iframe to editor examples

### DIFF
--- a/examples/emberEditorSandbox/fill.js
+++ b/examples/emberEditorSandbox/fill.js
@@ -1,0 +1,106 @@
+(function () {
+  const Sandbox = window.Sandbox;
+  if (!Sandbox) throw new Error("Sandbox utils must load before fill.js");
+
+  function handleFill(shapePayload, requestId, source, origin) {
+    const {
+      points: pointsRaw,
+      holesPoints = [],
+      fillParameters,
+      pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM,
+    } = shapePayload;
+
+    if (!pointsRaw || !Array.isArray(pointsRaw) || pointsRaw.length < 3) {
+      Sandbox.sendError(
+        source,
+        origin,
+        requestId,
+        "fill shapePayload requires points (array of {x,y}) with at least 3 vertices"
+      );
+      return;
+    }
+
+    const Maths = window.Stitch?.Math;
+    const Core = window.Stitch?.Core;
+    if (!Maths || !Core) {
+      Sandbox.sendError(
+        source,
+        origin,
+        requestId,
+        "Stitch library not loaded (build dist/stitch.global.js or serve from repo root)"
+      );
+      return;
+    }
+
+    const overlay = fillParameters?.overlay ?? {};
+    const stitchSpacing = overlay.stitchSpacing ?? 4;
+    const rowSpacing = overlay.rowSpacing ?? 0.25;
+    const angleDeg = overlay.angle ?? 45;
+    const angleInRadians = (Math.PI * angleDeg) / 180;
+    const underpath = fillParameters?.underpath !== false;
+    const startPoint = fillParameters?.startPoint;
+    const endPoint = fillParameters?.endPoint;
+    const underlays = fillParameters?.underlays ?? [];
+
+    const shape = Maths.Polyline.fromObjects(pointsRaw, true);
+    const holes = holesPoints.map((h) => Maths.Polyline.fromObjects(h, true));
+
+    const start = startPoint
+      ? new Maths.Vector(startPoint.x, startPoint.y)
+      : shape.vertices[0];
+    const end = endPoint
+      ? new Maths.Vector(endPoint.x, endPoint.y)
+      : shape.vertices[shape.vertices.length - 1];
+
+    const fillPattern = [
+      { rowOffsetMm: 0, rowPatternMm: [stitchSpacing] },
+      { rowOffsetMm: 0.33 * stitchSpacing, rowPatternMm: [stitchSpacing] },
+      { rowOffsetMm: 0.66 * stitchSpacing, rowPatternMm: [stitchSpacing] },
+    ];
+
+    const allStitches = [];
+
+    for (const underlay of underlays) {
+      const uAngle = (Math.PI * (underlay.angle ?? 45)) / 180;
+      const uRowSpacing = underlay.rowSpacing ?? rowSpacing;
+      const uStitchSpacing = underlay.stitchSpacing ?? stitchSpacing;
+      const uPattern = [
+        { rowOffsetMm: 0, rowPatternMm: [uStitchSpacing] },
+        { rowOffsetMm: 0.33 * uStitchSpacing, rowPatternMm: [uStitchSpacing] },
+        { rowOffsetMm: 0.66 * uStitchSpacing, rowPatternMm: [uStitchSpacing] },
+      ];
+      const underlayFill = new Core.Runs.AutoFill(
+        shape,
+        holes,
+        uAngle,
+        uRowSpacing,
+        uPattern,
+        1,
+        start,
+        start,
+        undefined,
+        underpath
+      );
+      allStitches.push(...underlayFill.getStitches(pixelsPerMm));
+    }
+
+    const fill = new Core.Runs.AutoFill(
+      shape,
+      holes,
+      angleInRadians,
+      rowSpacing,
+      fillPattern,
+      1,
+      start,
+      end,
+      undefined,
+      underpath
+    );
+    allStitches.push(...fill.getStitches(pixelsPerMm));
+
+    const points = Sandbox.stitchesToPoints(allStitches);
+    Sandbox.sendResult(source, origin, requestId, points);
+  }
+
+  Sandbox.handleFill = handleFill;
+})();

--- a/examples/emberEditorSandbox/index.html
+++ b/examples/emberEditorSandbox/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ember Editor Sandbox</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      padding: 1rem;
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f5f5f5;
+    }
+    .iframe-container {
+      margin: 0 auto;
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      padding: 1rem;
+    }
+    .iframe-container h1 {
+      margin: 0 0 1rem 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #333;
+    }
+    iframe {
+      display: block;
+      width: 100%;
+      height: 740px;
+      max-height: 80vh;
+      border: 1px solid #e0e0e0;
+      border-radius: 4px;
+      background: #fff;
+    }
+    .log {
+      margin-top: 1rem;
+      padding: 0.75rem;
+      background: #f9f9f9;
+      border: 1px solid #e0e0e0;
+      border-radius: 4px;
+      font-size: 0.875rem;
+      font-family: ui-monospace, monospace;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    .log-entry {
+      margin-bottom: 0.5rem;
+      padding: 0.25rem 0;
+      border-bottom: 1px solid #eee;
+    }
+    .log-entry:last-child {
+      border-bottom: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="iframe-container">
+    <h1>Ember Editor Sandbox</h1>
+    <iframe
+      id="editor-frame"
+      title="Ember Editor Sandbox"
+      src="https://v2.emberdesign.net/editor/sandbox/sandbox?new=true&sandbox=true&parent_origin=http://localhost:8081"
+
+    ></iframe>
+    <div class="log" id="stitch-log">
+      <strong>STITCH_REQUEST messages:</strong>
+      <div id="log-entries"></div>
+    </div>
+  </div>
+
+  <script src="../../dist/stitch.global.js"></script>
+  <script>window.Stitch || document.write('<script src="https://unpkg.com/@stitchables/stitchjs/dist/stitch.global.js">\x3C/script>')</script>
+  <script src="utils.js"></script>
+  <script src="fill.js"></script>
+  <script src="outline.js"></script>
+  <script>
+    window.addEventListener("message", (event) => {
+      const parsed = Sandbox.parseStitchRequest(event);
+      if (!parsed) return;
+
+      const { requestId, stitchType, shapePayload, source, origin } = parsed;
+
+      if (stitchType === "fill") {
+        try {
+          Sandbox.handleFill(shapePayload, requestId, source, origin);
+          Sandbox.logStitchRequest({ requestId, stitchType }, "sent STITCH_RESULT");
+        } catch (err) {
+          const msg = err.message || String(err);
+          Sandbox.sendError(source, origin, requestId, msg);
+          Sandbox.logStitchRequest({ requestId, stitchType }, "STITCH_ERROR: " + msg);
+        }
+        return;
+      }
+
+      if (stitchType === "outline") {
+        try {
+          Sandbox.handleOutline(shapePayload, requestId, source, origin);
+          Sandbox.logStitchRequest({ requestId, stitchType }, "sent STITCH_RESULT");
+        } catch (err) {
+          const msg = err.message || String(err);
+          Sandbox.sendError(source, origin, requestId, msg);
+          Sandbox.logStitchRequest({ requestId, stitchType }, "STITCH_ERROR: " + msg);
+        }
+        return;
+      }
+
+      Sandbox.sendError(source, origin, requestId, "Unsupported stitchType: " + stitchType);
+      Sandbox.logStitchRequest({ requestId, stitchType }, "STITCH_ERROR (unsupported type)");
+    });
+  </script>
+</body>
+</html>

--- a/examples/emberEditorSandbox/outline.js
+++ b/examples/emberEditorSandbox/outline.js
@@ -1,0 +1,167 @@
+(function () {
+  const Sandbox = window.Sandbox;
+  if (!Sandbox) throw new Error("Sandbox utils must load before outline.js");
+
+  function getStitch() {
+    const Stitch = window.Stitch;
+    if (!Stitch?.Math || !Stitch?.Core) return null;
+    return Stitch;
+  }
+
+  function verticesFromSpline(splineResampled) {
+    const Maths = window.Stitch?.Math;
+    if (!Maths) return null;
+    return splineResampled.map((p) => new Maths.Vector(p.x, p.y));
+  }
+
+  const outlineHandlers = {
+    single: function (shapePayload, requestId, source, origin) {
+      const Stitch = getStitch();
+      if (!Stitch) {
+        Sandbox.sendError(source, origin, requestId, "Stitch library not loaded");
+        return;
+      }
+      const { outlineParameters: params = {}, splineResampled, pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM } = shapePayload;
+      const stitchLength = params.stitchLength ?? 3;
+      const vertices = verticesFromSpline(splineResampled);
+      if (!vertices || vertices.length < 2) {
+        Sandbox.sendError(source, origin, requestId, "outline shapePayload.splineResampled must have at least 2 points");
+        return;
+      }
+      const run = new Stitch.Core.Runs.Run(vertices, { stitchLengthMm: stitchLength });
+      const stitches = run.getStitches(pixelsPerMm);
+      Sandbox.sendResult(source, origin, requestId, Sandbox.stitchesToPoints(stitches));
+    },
+
+    triple: function (shapePayload, requestId, source, origin) {
+      const Stitch = getStitch();
+      if (!Stitch) {
+        Sandbox.sendError(source, origin, requestId, "Stitch library not loaded");
+        return;
+      }
+      const { splineResampled, pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM } = shapePayload;
+      const vertices = verticesFromSpline(splineResampled);
+      if (!vertices || vertices.length < 2) {
+        Sandbox.sendError(source, origin, requestId, "outline shapePayload.splineResampled must have at least 2 points");
+        return;
+      }
+      const tripleRope = new Stitch.Core.Runs.TripleRope(vertices, {});
+      const stitches = tripleRope.getStitches(pixelsPerMm);
+      Sandbox.sendResult(source, origin, requestId, Sandbox.stitchesToPoints(stitches));
+    },
+
+    satin: function (shapePayload, requestId, source, origin) {
+      const Stitch = getStitch();
+      if (!Stitch) {
+        Sandbox.sendError(source, origin, requestId, "Stitch library not loaded");
+        return;
+      }
+      const { outlineParameters: params = {}, splineResampled: spline, isClosed, pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM } = shapePayload;
+      const { satinSettings = {} } = params;
+      const widthPx = satinSettings.width ?? 10;
+      if (!spline || spline.length < 2) {
+        Sandbox.sendError(source, origin, requestId, "outline shapePayload.splineResampled must have at least 2 points");
+        return;
+      }
+      const { Math: Maths } = Stitch;
+      const polyline = Maths.Polyline.fromObjects(spline, isClosed === true);
+      const density = satinSettings.density ?? 0.32;
+      const satin = new Stitch.Core.Runs.Satin(polyline, widthPx * 10, density);
+      const stitches = satin.getStitches(pixelsPerMm);
+      Sandbox.sendResult(source, origin, requestId, Sandbox.stitchesToPoints(stitches));
+    },
+
+    "double-rope-run": function (shapePayload, requestId, source, origin) {
+      const Stitch = getStitch();
+      if (!Stitch) {
+        Sandbox.sendError(source, origin, requestId, "Stitch library not loaded");
+        return;
+      }
+      const { outlineParameters: params = {}, splineResampled, pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM } = shapePayload;
+      const { width = 0.4, stitchLength = 3 } = params;
+      const vertices = verticesFromSpline(splineResampled);
+      if (!vertices || vertices.length < 2) {
+        Sandbox.sendError(source, origin, requestId, "outline shapePayload.splineResampled must have at least 2 points");
+        return;
+      }
+      const doubleRope = new Stitch.Core.Runs.DoubleRope(vertices, {
+        widthMm: width,
+        stitchLengthMm: stitchLength,
+      });
+      const stitches = doubleRope.getStitches(pixelsPerMm);
+      Sandbox.sendResult(source, origin, requestId, Sandbox.stitchesToPoints(stitches));
+    },
+
+    "triple-rope-run": function (shapePayload, requestId, source, origin) {
+      const Stitch = getStitch();
+      if (!Stitch) {
+        Sandbox.sendError(source, origin, requestId, "Stitch library not loaded");
+        return;
+      }
+      const { outlineParameters: params = {}, splineResampled, pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM } = shapePayload;
+      const { width = 0.4, stitchLength = 3 } = params;
+      const vertices = verticesFromSpline(splineResampled);
+      if (!vertices || vertices.length < 2) {
+        Sandbox.sendError(source, origin, requestId, "outline shapePayload.splineResampled must have at least 2 points");
+        return;
+      }
+      const tripleRope = new Stitch.Core.Runs.TripleRope(vertices, {
+        widthMm: width,
+        stitchLengthMm: stitchLength,
+      });
+      const stitches = tripleRope.getStitches(pixelsPerMm);
+      Sandbox.sendResult(source, origin, requestId, Sandbox.stitchesToPoints(stitches));
+    },
+
+    "e-stitch": function (shapePayload, requestId, source, origin) {
+      const Stitch = getStitch();
+      if (!Stitch) {
+        Sandbox.sendError(source, origin, requestId, "Stitch library not loaded");
+        return;
+      }
+      const { outlineParameters: params = {}, splineResampled, pixelsPerMm = Sandbox.DEFAULT_PIXELS_PER_MM } = shapePayload;
+      const { eStitchSettings = {} } = params;
+      const { width = 3, stitchLength = 3 } = eStitchSettings;
+      const isFlipped = eStitchSettings.isFlipped === true;
+      const vertices = verticesFromSpline(splineResampled);
+      if (!vertices || vertices.length < 2) {
+        Sandbox.sendError(source, origin, requestId, "outline shapePayload.splineResampled must have at least 2 points");
+        return;
+      }
+      const eStitch = new Stitch.Core.Runs.EStitch(vertices, {
+        widthMm: width,
+        stitchLengthMm: stitchLength,
+        isFlipped,
+      });
+      const stitches = eStitch.getStitches(pixelsPerMm);
+      Sandbox.sendResult(source, origin, requestId, Sandbox.stitchesToPoints(stitches));
+    },
+  };
+
+  function handleOutline(shapePayload, requestId, source, origin) {
+    const { outlineType } = shapePayload;
+    if (!outlineType || typeof outlineType !== "string") {
+      Sandbox.sendError(
+        source,
+        origin,
+        requestId,
+        "outline shapePayload must include outlineType: \"single\" | \"triple\" | \"satin\" | \"double-rope-run\" | \"triple-rope-run\" | \"e-stitch\""
+      );
+      return;
+    }
+    const handler = outlineHandlers[outlineType];
+    if (!handler) {
+      Sandbox.sendError(
+        source,
+        origin,
+        requestId,
+        "Unknown outlineType: " + outlineType + ". Supported: single, triple, satin, double-rope-run, triple-rope-run, e-stitch"
+      );
+      return;
+    }
+    handler(shapePayload, requestId, source, origin);
+  }
+
+  Sandbox.outlineHandlers = outlineHandlers;
+  Sandbox.handleOutline = handleOutline;
+})();

--- a/examples/emberEditorSandbox/utils.js
+++ b/examples/emberEditorSandbox/utils.js
@@ -1,0 +1,67 @@
+const Sandbox = window.Sandbox || {};
+
+Sandbox.ALLOWED_ORIGIN = "https://v2.emberdesign.net";
+Sandbox.DEFAULT_PIXELS_PER_MM = 10;
+
+Sandbox.logStitchRequest = function (payload, result) {
+  const logEl = document.getElementById("log-entries");
+  if (!logEl) return;
+  const entry = document.createElement("div");
+  entry.className = "log-entry";
+  entry.textContent = `${new Date().toLocaleTimeString()} — ${payload.stitchType} (${payload.requestId})${result ? ": " + result : ""}`;
+  logEl.appendChild(entry);
+  logEl.parentElement.scrollTop = logEl.parentElement.scrollHeight;
+};
+
+Sandbox.sendResult = function (source, origin, requestId, points) {
+  source.postMessage(
+    JSON.stringify({
+      type: "STITCH_RESULT",
+      requestId,
+      points: points.map((p) => ({ x: p.x, y: p.y, type: p.type })),
+    }),
+    origin
+  );
+};
+
+Sandbox.sendError = function (source, origin, requestId, error) {
+  source.postMessage(
+    JSON.stringify({
+      type: "STITCH_ERROR",
+      requestId,
+      error: String(error),
+    }),
+    origin
+  );
+};
+
+Sandbox.stitchesToPoints = function (stitches) {
+  return stitches.map((s) => ({
+    x: s.position.x,
+    y: s.position.y,
+    type: s.stitchType,
+  }));
+};
+
+/**
+ * Parse incoming postMessage data. Returns null if not a STITCH_REQUEST or invalid.
+ */
+Sandbox.parseStitchRequest = function (event) {
+  if (event.origin !== Sandbox.ALLOWED_ORIGIN) return null;
+  let data;
+  try {
+    data = typeof event.data === "string" ? JSON.parse(event.data) : event.data;
+  } catch {
+    return null;
+  }
+  if (data?.type !== "STITCH_REQUEST") return null;
+  return {
+    requestId: data.requestId,
+    stitchType: data.stitchType,
+    shapePayload: data.shapePayload,
+    source: event.source,
+    origin: event.origin,
+  };
+};
+
+window.Sandbox = Sandbox;


### PR DESCRIPTION
Embeds the Ember editor as an iframe into an example page and as long as it's hosted on the github stitchables domain or locally with a parent of localhost:8081, you can route your own stitch response to it using the handlers.

Locally, i just use "npx serve . --listen 8081" to test things