### PR TITLE
Allow satins to be split

### DIFF
--- a/examples/splitSatinExample.html
+++ b/examples/splitSatinExample.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html>
+<head>
+  <title>Split Satin Example</title>
+  <script src="../dist/stitch.global.js"></script>
+  <script>window.Stitch || document.write('<script src="https://unpkg.com/@stitchables/stitchjs/dist/stitch.global.js">\x3C/script>')</script>
+  <style>
+    body {
+      margin: 0;
+      background: #f0f0f0;
+      font-family: system-ui, sans-serif;
+    }
+    #labels {
+      position: fixed;
+      top: 16px;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 10px;
+      padding: 0 16px;
+      pointer-events: none;
+      z-index: 1;
+    }
+    #labels span {
+      background: rgba(255, 255, 255, 0.85);
+      padding: 6px 12px;
+      border-radius: 6px;
+      font-size: 13px;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    }
+  </style>
+</head>
+<body>
+<div id="labels">
+  <span>AutoRoute</span>
+  <span>1: no split</span>
+  <span>2: split 8mm</span>
+  <span>3: split 5mm</span>
+  <span>4: split 3mm</span>
+</div>
+<script>
+  function makeTaperedSatin(centerX, topY, length, startWidth, endWidth, steps) {
+    const vertices = [];
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const y = topY + t * length;
+      const w = startWidth + t * (endWidth - startWidth);
+      vertices.push(new Stitch.Math.Vector(centerX - w / 2, y));
+      vertices.push(new Stitch.Math.Vector(centerX + w / 2, y));
+    }
+    return vertices;
+  }
+
+  const pattern = new Stitch.Core.Pattern(900, 420);
+  const travelLengthMm = 2;
+  const taper = { topY: 50, length: 320, startWidth: 8, endWidth: 90, steps: 28 };
+
+  const routedSatins = [
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(110, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      { densityMm: 0.4, travelLengthMm },
+    ),
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(310, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      { densityMm: 0.4, travelLengthMm, splitSatinMm: 8 },
+    ),
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(510, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      { densityMm: 0.4, travelLengthMm, splitSatinMm: 5 },
+    ),
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(710, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      { densityMm: 0.3, travelLengthMm, splitSatinMm: 3 },
+    ),
+  ];
+
+  const thread = pattern.addThread(190, 55, 55);
+  thread.addRun(new Stitch.Core.RoutedRuns.AutoRoute(routedSatins));
+
+  let canvas = Stitch.Graphics.getCanvas(pattern, window.innerWidth, window.innerHeight, 5, 1.5);
+  canvas.setAttribute('style', 'margin: auto; position: absolute; inset: 0;');
+  document.body.append(canvas);
+
+  let modal = Stitch.Browser.Modal.createDownloadModal(pattern, 'splitSatinExample', 10, 500);
+  document.body.appendChild(modal.container);
+  window.addEventListener('click', (e) => {
+    if (e.target === modal.container) modal.close();
+  });
+  window.addEventListener('keydown', (e) => {
+    if (e.code === 'KeyD') modal.open();
+  });
+
+  window.addEventListener('resize', Stitch.Browser.Utils.debounce(() => {
+    canvas.remove();
+    canvas = Stitch.Graphics.getCanvas(pattern, window.innerWidth, window.innerHeight, 5, 1.5);
+    canvas.setAttribute('style', 'margin: auto; position: absolute; inset: 0;');
+    document.body.append(canvas);
+  }, 10));
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stitchables/stitchjs",
   "license": "MIT",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "dist/stitch.js",
   "module": "dist/stitch.mjs",
   "types": "dist/stitch.d.ts",

--- a/src/Core/RoutedRuns/RoutedSatin.ts
+++ b/src/Core/RoutedRuns/RoutedSatin.ts
@@ -23,6 +23,7 @@ export class RoutedSatin implements IRoutedRun {
   densityMm: number;
   travelLengthMm: number;
   travelToleranceMm: number;
+  splitSatinMm: number | undefined;
   underlays: {
     type: string;
     options?: UnderlayOptions;
@@ -34,6 +35,7 @@ export class RoutedSatin implements IRoutedRun {
       densityMm?: number;
       travelLengthMm?: number;
       travelToleranceMm?: number;
+      splitSatinMm?: number;
       underlays?: {
         type: string;
         options?: UnderlayOptions;
@@ -44,6 +46,7 @@ export class RoutedSatin implements IRoutedRun {
     this.densityMm = options?.densityMm ?? 0.2;
     this.travelLengthMm = options?.travelLengthMm ?? 3;
     this.travelToleranceMm = options?.travelToleranceMm ?? 0.1;
+    this.splitSatinMm = options?.splitSatinMm;
     this.underlays = options?.underlays ?? [];
   }
 
@@ -98,6 +101,7 @@ export class RoutedSatin implements IRoutedRun {
       densityMm: this.densityMm,
       travelLengthMm: this.travelLengthMm,
       travelToleranceMm: this.travelToleranceMm,
+      splitSatinMm: this.splitSatinMm,
     };
     const classicSatin = new ClassicSatin(this.quadStripVertices, options);
     return classicSatin.getStitches(pixelsPerMm);

--- a/src/Core/Runs/ClassicSatin.ts
+++ b/src/Core/Runs/ClassicSatin.ts
@@ -38,6 +38,7 @@ export class ClassicSatin implements IRun {
   densityMm: number;
   travelLengthMm: number;
   travelToleranceMm: number;
+  splitSatinMm: number | undefined;
   underlays: { type: string; options?: UnderlayOptions }[];
   lineData: { left: SatinLineData; right: SatinLineData; center: SatinLineData };
   isClosed: boolean;
@@ -50,6 +51,7 @@ export class ClassicSatin implements IRun {
       densityMm?: number;
       travelLengthMm?: number;
       travelToleranceMm?: number;
+      splitSatinMm?: number;
       underlays?: { type: string; options?: UnderlayOptions }[];
     },
   ) {
@@ -66,6 +68,7 @@ export class ClassicSatin implements IRun {
     this.densityMm = options?.densityMm ?? 0.4;
     this.travelLengthMm = options?.travelLengthMm ?? 3;
     this.travelToleranceMm = options?.travelToleranceMm ?? 1;
+    this.splitSatinMm = options?.splitSatinMm;
     this.underlays = options?.underlays ?? [];
   }
 
@@ -287,17 +290,38 @@ export class ClassicSatin implements IRun {
   getFullSatin(pixelsPerMm: number): LineString {
     const countCrosses =
       Math.round(this.lineData.center.len / (this.densityMm * pixelsPerMm)) + 1;
-    const coords: Coordinate[] = [];
+    const rawCoords: Coordinate[] = [];
     for (let i = 0; i < (this.isClosed ? countCrosses : countCrosses + 1); i++) {
       const locationIndex = this.lineData.center.lenLocMap.getLocation(
         (i / countCrosses) * this.lineData.center.len,
       );
       const left: Coordinate = this.lineData.left.locIndex.extractPoint(locationIndex);
       const right: Coordinate = this.lineData.right.locIndex.extractPoint(locationIndex);
-      coords.push(left);
-      coords.push(right);
+      rawCoords.push(left);
+      rawCoords.push(right);
     }
-    return geometryFactory.createLineString(coords);
+
+    if (this.splitSatinMm === undefined || this.splitSatinMm <= 0) {
+      return geometryFactory.createLineString(rawCoords);
+    }
+
+    const splitPx = this.splitSatinMm * pixelsPerMm;
+    const finalCoords: Coordinate[] = [rawCoords[0]];
+    for (let i = 1; i < rawCoords.length; i++) {
+      const a = rawCoords[i - 1];
+      const b = rawCoords[i];
+      const dist = a.distance(b);
+      if (dist > splitPx) {
+        const numSegments = Math.ceil(dist / splitPx);
+        for (let j = 1; j <= numSegments; j++) {
+          const t = j / numSegments;
+          finalCoords.push(new Coordinate(a.x + t * (b.x - a.x), a.y + t * (b.y - a.y)));
+        }
+      } else {
+        finalCoords.push(b);
+      }
+    }
+    return geometryFactory.createLineString(finalCoords);
   }
 
   getUnderlayOptionsOrDefault(


### PR DESCRIPTION
Adds an option argument to satins `splitSatinMm` allowing you to define a length at which satins should start splitting. Also adds an example