### PR TITLE
Staggered split satins

### DIFF
--- a/examples/splitSatinExample.html
+++ b/examples/splitSatinExample.html
@@ -5,41 +5,15 @@
   <script src="../dist/stitch.global.js"></script>
   <script>window.Stitch || document.write('<script src="https://unpkg.com/@stitchables/stitchjs/dist/stitch.global.js">\x3C/script>')</script>
   <style>
-    body {
-      margin: 0;
-      background: #f0f0f0;
-      font-family: system-ui, sans-serif;
-    }
-    #labels {
-      position: fixed;
-      top: 16px;
-      left: 0;
-      right: 0;
-      display: flex;
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 10px;
-      padding: 0 16px;
-      pointer-events: none;
-      z-index: 1;
-    }
-    #labels span {
-      background: rgba(255, 255, 255, 0.85);
-      padding: 6px 12px;
-      border-radius: 6px;
-      font-size: 13px;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
-    }
+    body { margin: 0; background: #f0f0f0; font: 13px system-ui, sans-serif; }
+    #labels { position: fixed; top: 12px; left: 12px; pointer-events: none; }
+    #render { position: absolute; inset: 0; }
+    #render canvas { position: absolute; inset: 0; margin: auto; pointer-events: none; }
   </style>
 </head>
 <body>
-<div id="labels">
-  <span>AutoRoute</span>
-  <span>1: no split</span>
-  <span>2: split 8mm</span>
-  <span>3: split 5mm</span>
-  <span>4: split 3mm</span>
-</div>
+<div id="labels">1: no split · 2: split · 3: stagger · 4: square stagger</div>
+<div id="render"></div>
 <script>
   function makeTaperedSatin(centerX, topY, length, startWidth, endWidth, steps) {
     const vertices = [];
@@ -53,51 +27,69 @@
     return vertices;
   }
 
-  const pattern = new Stitch.Core.Pattern(900, 420);
-  const travelLengthMm = 2;
+  const split = { maxWidthMm: 7 };
+  const splitStaggered = { maxWidthMm: 7, staggerCycles: 4, staggerAmountMm: 2 };
   const taper = { topY: 50, length: 320, startWidth: 8, endWidth: 90, steps: 28 };
+  const opts = { densityMm: 0.4, travelLengthMm: 2 };
 
-  const routedSatins = [
-    new Stitch.Core.RoutedRuns.RoutedSatin(
-      makeTaperedSatin(110, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
-      { densityMm: 0.4, travelLengthMm },
-    ),
-    new Stitch.Core.RoutedRuns.RoutedSatin(
-      makeTaperedSatin(310, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
-      { densityMm: 0.4, travelLengthMm, splitSatinMm: 8 },
-    ),
-    new Stitch.Core.RoutedRuns.RoutedSatin(
-      makeTaperedSatin(510, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
-      { densityMm: 0.4, travelLengthMm, splitSatinMm: 5 },
-    ),
-    new Stitch.Core.RoutedRuns.RoutedSatin(
-      makeTaperedSatin(710, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
-      { densityMm: 0.3, travelLengthMm, splitSatinMm: 3 },
-    ),
-  ];
-
+  const pattern = new Stitch.Core.Pattern(900, 420);
   const thread = pattern.addThread(190, 55, 55);
-  thread.addRun(new Stitch.Core.RoutedRuns.AutoRoute(routedSatins));
+  thread.addRun(new Stitch.Core.RoutedRuns.AutoRoute([
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(120, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      opts,
+    ),
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(320, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      { ...opts, split },
+    ),
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(520, taper.topY, taper.length, taper.startWidth, taper.endWidth, taper.steps),
+      { ...opts, split: splitStaggered },
+    ),
+    new Stitch.Core.RoutedRuns.RoutedSatin(
+      makeTaperedSatin(720, 50, 50, 50, 50, 40),
+      { ...opts, split: splitStaggered },
+    ),
+  ]));
 
-  let canvas = Stitch.Graphics.getCanvas(pattern, window.innerWidth, window.innerHeight, 5, 1.5);
-  canvas.setAttribute('style', 'margin: auto; position: absolute; inset: 0;');
-  document.body.append(canvas);
+  function render() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const container = document.getElementById('render');
+    container.replaceChildren();
 
-  let modal = Stitch.Browser.Modal.createDownloadModal(pattern, 'splitSatinExample', 10, 500);
+    const canvas = Stitch.Graphics.getCanvas(pattern, w, h, 5, 1.5);
+    container.append(canvas);
+
+    const plan = pattern.getStitchPlan(w, h, 5);
+    const scale = 5 / plan.pixelsPerUnit;
+    const translate = new Stitch.Math.Vector(0.5 * (w - plan.width), 0.5 * (h - plan.height));
+    const dots = document.createElement('canvas');
+    dots.width = w;
+    dots.height = h;
+    const ctx = dots.getContext('2d');
+    container.append(dots);
+
+    for (const t of plan.threads) {
+      for (const run of t.runs) {
+        for (const stitch of run) {
+          if (stitch.stitchType !== 0) continue;
+          const p = stitch.position.multiply(scale).add(translate);
+          ctx.fillStyle = '#000';
+          ctx.fillRect(p.x, p.y, 2, 2);
+        }
+      }
+    }
+  }
+
+  render();
+
+  const modal = Stitch.Browser.Modal.createDownloadModal(pattern, 'splitSatinExample', 10, 500);
   document.body.appendChild(modal.container);
-  window.addEventListener('click', (e) => {
-    if (e.target === modal.container) modal.close();
-  });
-  window.addEventListener('keydown', (e) => {
-    if (e.code === 'KeyD') modal.open();
-  });
-
-  window.addEventListener('resize', Stitch.Browser.Utils.debounce(() => {
-    canvas.remove();
-    canvas = Stitch.Graphics.getCanvas(pattern, window.innerWidth, window.innerHeight, 5, 1.5);
-    canvas.setAttribute('style', 'margin: auto; position: absolute; inset: 0;');
-    document.body.append(canvas);
-  }, 10));
+  window.addEventListener('click', (e) => { if (e.target === modal.container) modal.close(); });
+  window.addEventListener('keydown', (e) => { if (e.code === 'KeyD') modal.open(); });
+  window.addEventListener('resize', Stitch.Browser.Utils.debounce(render, 10));
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stitchables/stitchjs",
   "license": "MIT",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "main": "dist/stitch.js",
   "module": "dist/stitch.mjs",
   "types": "dist/stitch.d.ts",

--- a/src/Core/RoutedRuns/RoutedSatin.ts
+++ b/src/Core/RoutedRuns/RoutedSatin.ts
@@ -6,7 +6,7 @@ import CascadedPolygonUnion from 'jsts/org/locationtech/jts/operation/union/Casc
 import ArrayList from 'jsts/java/util/ArrayList';
 import Polygonizer from 'jsts/org/locationtech/jts/operation/polygonize/Polygonizer';
 import { geometryFactory } from '../../util/jsts';
-import { ClassicSatin } from '../Runs/ClassicSatin';
+import { ClassicSatin, SatinSplitOptions } from '../Runs/ClassicSatin';
 
 interface UnderlayOptions {
   stitchLengthMm?: number;
@@ -23,7 +23,7 @@ export class RoutedSatin implements IRoutedRun {
   densityMm: number;
   travelLengthMm: number;
   travelToleranceMm: number;
-  splitSatinMm: number | undefined;
+  split: SatinSplitOptions | undefined;
   underlays: {
     type: string;
     options?: UnderlayOptions;
@@ -35,7 +35,7 @@ export class RoutedSatin implements IRoutedRun {
       densityMm?: number;
       travelLengthMm?: number;
       travelToleranceMm?: number;
-      splitSatinMm?: number;
+      split?: SatinSplitOptions;
       underlays?: {
         type: string;
         options?: UnderlayOptions;
@@ -46,7 +46,7 @@ export class RoutedSatin implements IRoutedRun {
     this.densityMm = options?.densityMm ?? 0.2;
     this.travelLengthMm = options?.travelLengthMm ?? 3;
     this.travelToleranceMm = options?.travelToleranceMm ?? 0.1;
-    this.splitSatinMm = options?.splitSatinMm;
+    this.split = options?.split;
     this.underlays = options?.underlays ?? [];
   }
 
@@ -101,7 +101,7 @@ export class RoutedSatin implements IRoutedRun {
       densityMm: this.densityMm,
       travelLengthMm: this.travelLengthMm,
       travelToleranceMm: this.travelToleranceMm,
-      splitSatinMm: this.splitSatinMm,
+      split: this.split,
     };
     const classicSatin = new ClassicSatin(this.quadStripVertices, options);
     return classicSatin.getStitches(pixelsPerMm);

--- a/src/Core/Runs/ClassicSatin.ts
+++ b/src/Core/Runs/ClassicSatin.ts
@@ -23,6 +23,12 @@ interface UnderlayOptions {
   sideInsetMm?: number;
 }
 
+export interface SatinSplitOptions {
+  maxWidthMm: number;
+  staggerCycles?: number;
+  staggerAmountMm?: number;
+}
+
 interface SatinLineData {
   line: LineString;
   len: number;
@@ -38,7 +44,7 @@ export class ClassicSatin implements IRun {
   densityMm: number;
   travelLengthMm: number;
   travelToleranceMm: number;
-  splitSatinMm: number | undefined;
+  split: SatinSplitOptions | undefined;
   underlays: { type: string; options?: UnderlayOptions }[];
   lineData: { left: SatinLineData; right: SatinLineData; center: SatinLineData };
   isClosed: boolean;
@@ -51,7 +57,7 @@ export class ClassicSatin implements IRun {
       densityMm?: number;
       travelLengthMm?: number;
       travelToleranceMm?: number;
-      splitSatinMm?: number;
+      split?: SatinSplitOptions;
       underlays?: { type: string; options?: UnderlayOptions }[];
     },
   ) {
@@ -68,7 +74,7 @@ export class ClassicSatin implements IRun {
     this.densityMm = options?.densityMm ?? 0.4;
     this.travelLengthMm = options?.travelLengthMm ?? 3;
     this.travelToleranceMm = options?.travelToleranceMm ?? 1;
-    this.splitSatinMm = options?.splitSatinMm;
+    this.split = options?.split;
     this.underlays = options?.underlays ?? [];
   }
 
@@ -301,27 +307,88 @@ export class ClassicSatin implements IRun {
       rawCoords.push(right);
     }
 
-    if (this.splitSatinMm === undefined || this.splitSatinMm <= 0) {
+    if (this.split === undefined || this.split.maxWidthMm <= 0) {
       return geometryFactory.createLineString(rawCoords);
     }
 
-    const splitPx = this.splitSatinMm * pixelsPerMm;
+    const splitPx = this.split.maxWidthMm * pixelsPerMm;
     const finalCoords: Coordinate[] = [rawCoords[0]];
     for (let i = 1; i < rawCoords.length; i++) {
-      const a = rawCoords[i - 1];
-      const b = rawCoords[i];
-      const dist = a.distance(b);
-      if (dist > splitPx) {
-        const numSegments = Math.ceil(dist / splitPx);
-        for (let j = 1; j <= numSegments; j++) {
-          const t = j / numSegments;
-          finalCoords.push(new Coordinate(a.x + t * (b.x - a.x), a.y + t * (b.y - a.y)));
-        }
-      } else {
-        finalCoords.push(b);
+      const crossIdx = i % 2 === 1 ? (i - 1) / 2 : undefined;
+      const segment = { a: rawCoords[i - 1], b: rawCoords[i] };
+      for (const coord of this.splitSegment(
+        segment,
+        this.split,
+        splitPx,
+        crossIdx,
+        pixelsPerMm,
+      )) {
+        finalCoords.push(coord);
       }
     }
     return geometryFactory.createLineString(finalCoords);
+  }
+
+  splitSegment(
+    segment: { a: Coordinate; b: Coordinate },
+    split: SatinSplitOptions,
+    splitPx: number,
+    crossIdx: number | undefined,
+    pixelsPerMm: number,
+  ): Coordinate[] {
+    const { a, b } = segment;
+    const dist = a.distance(b);
+    if (dist <= splitPx) {
+      return [b];
+    }
+
+    const staggerCycles = split.staggerCycles;
+    const staggerEnabled = staggerCycles !== undefined && staggerCycles > 1;
+    if (staggerEnabled && crossIdx === undefined) {
+      return [b];
+    }
+
+    const numSegments = Math.ceil(dist / splitPx);
+    const rowShift =
+      staggerEnabled && crossIdx !== undefined
+        ? this.getStaggerRowShift(
+            crossIdx,
+            staggerCycles,
+            split,
+            dist,
+            numSegments,
+            splitPx,
+            pixelsPerMm,
+          )
+        : 0;
+
+    const coords: Coordinate[] = [];
+    for (let j = 1; j < numSegments; j++) {
+      const t = Math.max(0, Math.min(1, j / numSegments + rowShift));
+      const p = Vector.fromObject(a).lerp(Vector.fromObject(b), t);
+      coords.push(new Coordinate(p.x, p.y));
+    }
+
+    coords.push(b);
+    return coords;
+  }
+
+  private getStaggerRowShift(
+    crossIdx: number,
+    staggerCycles: number,
+    split: SatinSplitOptions,
+    dist: number,
+    numSegments: number,
+    splitPx: number,
+    pixelsPerMm: number,
+  ): number {
+    const slotWidthT = 1 / numSegments;
+    const staggerAmountMm = split.staggerAmountMm ?? 0.75 * split.maxWidthMm;
+    const maxOffsetT = Math.min((staggerAmountMm * pixelsPerMm) / dist, slotWidthT);
+    const tierFill = Math.min(1, dist / (numSegments * splitPx));
+    const magnitudeScale = ((crossIdx % staggerCycles) + 1) / staggerCycles;
+    const direction = crossIdx % 2 === 0 ? -1 : 1;
+    return direction * maxOffsetT * tierFill * magnitudeScale;
   }
 
   getUnderlayOptionsOrDefault(

--- a/src/Core/Runs/ClassicSatin.ts
+++ b/src/Core/Runs/ClassicSatin.ts
@@ -383,7 +383,7 @@ export class ClassicSatin implements IRun {
     pixelsPerMm: number,
   ): number {
     const slotWidthT = 1 / numSegments;
-    const staggerAmountMm = split.staggerAmountMm ?? 0.75 * split.maxWidthMm;
+    const staggerAmountMm = split.staggerAmountMm ?? 2;
     const maxOffsetT = Math.min((staggerAmountMm * pixelsPerMm) / dist, slotWidthT);
     const tierFill = Math.min(1, dist / (numSegments * splitPx));
     const magnitudeScale = ((crossIdx % staggerCycles) + 1) / staggerCycles;


### PR DESCRIPTION
Adds optional satin splitting to `ClassicSatin` and `RoutedSatin`. Cross-stitches wider than `maxWidthMm` are subdivided, optional stagger offsets split points row-by-row.

```
export interface SatinSplitOptions {
  maxWidthMm: number; // max cross-stitch width in mm before split stitches are inserted
  staggerCycles?: number; // number of rows before the stagger pattern repeats, must be > 1 to enable stagger
  staggerAmountMm?: number; // max split-point offset in mm along each cross-stitch
}
```

<img width="990" height="538" alt="image" src="https://github.com/user-attachments/assets/a4981fa1-5cab-4adf-a94d-c73c990f7975" />