### PR TITLE
Fixes a bug with center run underlays on classic satin, introduced by split satin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stitchables/stitchjs",
   "license": "MIT",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "main": "dist/stitch.js",
   "module": "dist/stitch.mjs",
   "types": "dist/stitch.d.ts",

--- a/src/Core/Runs/ClassicSatin.ts
+++ b/src/Core/Runs/ClassicSatin.ts
@@ -156,19 +156,23 @@ export class ClassicSatin implements IRun {
   }
 
   getTravelStitches(subsection: LineString, pixelsPerMm: number): Stitch[] {
-    const travelStitches: Stitch[] = [];
-    if (subsection.getNumPoints() < 4) {
-      const last = subsection.getEndPoint();
-      travelStitches.push(new Stitch(new Vector(last.x, last.y), StitchType.TRAVEL));
-      return travelStitches;
+    if (subsection.getNumPoints() < 2) {
+      return [];
     }
-    const vertices: Vector[] = [];
-    for (let i = 1; i < subsection.getNumPoints(); i++) {
-      const prev = subsection.getCoordinateN(i - 1);
-      const curr = subsection.getCoordinateN(i);
-      const midpoint = new Vector(0.5 * (prev.x + curr.x), 0.5 * (prev.y + curr.y));
-      vertices.push(midpoint);
+    const start = subsection.getCoordinateN(0);
+    const end = subsection.getCoordinateN(subsection.getNumPoints() - 1);
+    const startLen = this.lineData.center.lenIndex.project(start);
+    const endLen = this.lineData.center.lenIndex.project(end);
+    if (Math.abs(startLen - endLen) < 0.5 * pixelsPerMm) {
+      return [new Stitch(new Vector(end.x, end.y), StitchType.TRAVEL)];
     }
+    const centerSection = this.lineData.center.lenIndex.extractLine(startLen, endLen);
+    if (centerSection.getNumPoints() < 2) {
+      return [new Stitch(new Vector(end.x, end.y), StitchType.TRAVEL)];
+    }
+    const vertices: Vector[] = centerSection
+      .getCoordinates()
+      .map((c: Coordinate) => new Vector(c.x, c.y));
     const travelRun = new Run(vertices, {
       stitchLengthMm: this.travelLengthMm,
       stitchToleranceMm: this.travelToleranceMm,


### PR DESCRIPTION
A regression was introduced in 1.0.20 that causes center run underlays on classic satin to zig zag back in forth because they were trying to pull the centerline coordinates from split satin points.

`getTravelStitches` now follows the real centerline instead of midpoints of the split satin path, which were previously weaving across the column like a fake zigzag underlay.

Heres the bug:
https://github.com/user-attachments/assets/48d03ee8-4a31-432c-a859-d343bd93cf69
